### PR TITLE
Feat: Add Extra Parameters to puppet-server.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ Bootstraps the installation and configuration of a new Puppetserver.
 | `eyamlKeyPath`         | string | false     | Allows you to specify the path to where you will store your eyaml public/private keys.                                                         |
 | `SkipOptionalPrompts`  | switch | false     | If declared will skip all information gathering prompts.                                                                                       |
 | `SkipConfirmation`     | switch | false     | If declared will skip the confirmation prompt.                                                                                                 |
+| `R10kVersion`     | string | false     | Allows you to specify a version of the r10k gem to be installed, this is useful when constrained by the version of Ruby you are running                                                                                                 |
+| `HieraEyamlVersion`     | string | false     | Allows you to specify a version of the hiera-eyaml gem to be installed, this is useful when constrained by the version of Ruby you are running                                                                                                 |
+| `PuppetAgentPath`     | string | false     | The path to the `puppet` binary this is often not available in `PATH` so using the full path is preferred |
+| `PuppetserverPath`     | string | false     | The path to the `puppetserver` binary this is often not available in `PATH` so using the full path is preferred |
+| `R10KPath`     | string | false     | The path to the `r10k` binary it's useful to be able to override this when working with rbenv or rvm |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # puppet-bootstrap
+
 This repo contains the scripts required to bootstrap a Puppet installation.
 These scripts are likely only relevant to Brownserve projects.
 
-# puppet-agent.ps1
+## puppet-agent.ps1
+
 This sets up Puppet agent on Linux/Windows nodes.
 
 | Parameter Name          | Type    | Mandatory | Description                                                                                                                                                        |
@@ -23,8 +25,8 @@ This sets up Puppet agent on Linux/Windows nodes.
 | `SkipConfirmation`      | switch  | false     | If declared this will skip the confirmation prompt.                                                                                                                |
 | `SkipInitialRun`      | switch  | false     | If declared this will skip the first run of Puppet.                                                                                                                |
 
+## puppet-server.ps1
 
-# puppet-server.ps1
 Bootstraps the installation and configuration of a new Puppetserver.
 
 | Parameter Name         | Type   | Mandatory | Description                                                                                                                                    |

--- a/puppet-server.ps1
+++ b/puppet-server.ps1
@@ -420,6 +420,10 @@ Major Puppet version: $MajorVersion`n
     if ($eyamlPrivateKey)
     {
         $ConfirmationMessage += "Install eyaml: true`n"
+        if ($HieraEyamlVersion)
+        {
+            $ConfirmationMessage += "hiera-eyaml version: $HieraEyamlVersion`n"
+        }
         $ConfirmationMessage += "Key path: $eyamlKeyPath`n"
     }
     else
@@ -432,6 +436,10 @@ Major Puppet version: $MajorVersion`n
 Install r10k: true
 GitHub repository: $GitHubRepo`n
 "@
+        if ($R10kVersion)
+        {
+            $ConfirmationMessage += "r10k version: $R10kVersion`n"
+        }
         if ($DeployKeyPath)
         {
             $ConfirmationMessage += "Deploy key: $DeployKeyPath`n"


### PR DESCRIPTION
Gems like r10k and hiera-eyaml are built against newer versions of Ruby (3+) and by default Ubuntu has 2.X in it's native repositories.

By allowing the user to pass a version parameter it means we are able to install a given version of each of the gems.
That way the user can match those to the version of Ruby they are using.